### PR TITLE
do not generate region page statically

### DIFF
--- a/apps/storefront/src/app/[countryCode]/(main)/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/page.tsx
@@ -1,27 +1,13 @@
-import { listRegions } from "@/lib/data/regions"
 import FeaturedProducts from "@/modules/home/components/featured-products"
 import Hero from "@/modules/home/components/hero"
 import SkeletonFeaturedProducts from "@/modules/skeletons/templates/skeleton-featured-products"
 import { Metadata } from "next"
 import { Suspense } from "react"
 
-export const dynamicParams = true
-
 export const metadata: Metadata = {
   title: "Medusa Next.js Starter Template",
   description:
     "A performant frontend ecommerce starter template with Next.js 14 and Medusa.",
-}
-
-export async function generateStaticParams() {
-  const countryCodes = await listRegions().then(
-    (regions) =>
-      regions
-        ?.map((r) => r.countries?.map((c) => c.iso_2))
-        .flat()
-        .filter(Boolean) as string[]
-  )
-  return countryCodes.map((countryCode) => ({ countryCode }))
 }
 
 export default async function Home(props: {


### PR DESCRIPTION
This is the scenario:
- Store has no regions yet, cause the BE was just provisioned and deployed
- FE is built, the region does not exist, so the route `/[countryCode]` is not rendered on build, cause no regions were found
- Region is created on the BE
- `/[countryCode]` is refreshed. Rendering fails with `Error: Page changed from static to dynamic at runtime /dk, reason: cookies see more here https://nextjs.org/docs/messages/app-static-to-dynamic-error"`.
This happens because the page does a lot of data fetching and uses cookies for it, which is a dynamic API. But the page was meant to be rendered as static, so NextJS fails.

This PR removes the pre-rendering to always render the page dynamically. This also means the page will have fresh data, e.g. featured products.