### PR TITLE
remove force-cache

### DIFF
--- a/apps/storefront/src/lib/data/approvals.ts
+++ b/apps/storefront/src/lib/data/approvals.ts
@@ -54,7 +54,6 @@ export const listApprovals = async ({
       headers,
       next,
       credentials: "include",
-      cache: "force-cache",
     }
   )
 

--- a/apps/storefront/src/lib/data/cart.ts
+++ b/apps/storefront/src/lib/data/cart.ts
@@ -3,11 +3,11 @@
 import { sdk } from "@/lib/config"
 import medusaError from "@/lib/util/medusa-error"
 import { StoreApprovalResponse } from "@/types/approval"
+import { B2BCart } from "@/types/global"
 import { HttpTypes } from "@medusajs/types"
 import { track } from "@vercel/analytics/server"
 import { revalidateTag } from "next/cache"
 import { redirect } from "next/navigation"
-import { B2BCart } from "@/types/global"
 import {
   getAuthHeaders,
   getCacheOptions,
@@ -44,7 +44,6 @@ export async function retrieveCart(id?: string) {
       },
       headers,
       next,
-      cache: "force-cache",
     })
     .then(({ cart }) => {
       return cart as B2BCart

--- a/apps/storefront/src/lib/data/categories.ts
+++ b/apps/storefront/src/lib/data/categories.ts
@@ -24,7 +24,6 @@ export const listCategories = async (
           ...query,
         },
         next,
-        cache: "force-cache",
       }
     )
     .then(({ product_categories }) => product_categories)
@@ -48,7 +47,6 @@ export const getCategoryByHandle = async (
           handle,
         },
         next,
-        cache: "force-cache",
       }
     )
     .then(({ product_categories }) => product_categories[0])

--- a/apps/storefront/src/lib/data/collections.ts
+++ b/apps/storefront/src/lib/data/collections.ts
@@ -14,7 +14,6 @@ export const retrieveCollection = async (id: string) => {
       `/store/collections/${id}`,
       {
         next,
-        cache: "force-cache",
       }
     )
     .then(({ collection }) => collection)
@@ -36,7 +35,6 @@ export const listCollections = async (
       {
         query: queryParams,
         next,
-        cache: "force-cache",
       }
     )
     .then(({ collections }) => ({ collections, count: collections.length }))
@@ -53,7 +51,6 @@ export const getCollectionByHandle = async (
     .fetch<HttpTypes.StoreCollectionListResponse>(`/store/collections`, {
       query: { handle },
       next,
-      cache: "force-cache",
     })
     .then(({ collections }) => collections[0])
 }

--- a/apps/storefront/src/lib/data/customer.ts
+++ b/apps/storefront/src/lib/data/customer.ts
@@ -40,7 +40,6 @@ export const retrieveCustomer = async (): Promise<B2BCustomer | null> => {
       },
       headers,
       next,
-      cache: "force-cache",
     })
     .then(({ customer }) => customer as B2BCustomer)
     .catch(() => null)

--- a/apps/storefront/src/lib/data/fulfillment.ts
+++ b/apps/storefront/src/lib/data/fulfillment.ts
@@ -22,7 +22,6 @@ export const listCartShippingMethods = async (cartId: string) => {
         query: { cart_id: cartId },
         headers,
         next,
-        cache: "force-cache",
       }
     )
     .then(({ shipping_options }) => shipping_options)
@@ -50,7 +49,6 @@ export const listCartFreeShippingPrices = async (
       query: { cart_id: cartId },
       headers,
       next,
-      cache: "force-cache",
     })
     .then((data) => data.prices)
 }

--- a/apps/storefront/src/lib/data/orders.ts
+++ b/apps/storefront/src/lib/data/orders.ts
@@ -23,7 +23,6 @@ export const retrieveOrder = async (id: string) => {
       },
       headers,
       next,
-      cache: "force-cache",
     })
     .then(({ order }) => order)
     .catch((err) => medusaError(err))
@@ -55,7 +54,6 @@ export const listOrders = async (
       },
       headers,
       next,
-      cache: "force-cache",
     })
     .then(({ orders }) => orders)
     .catch((err) => medusaError(err))

--- a/apps/storefront/src/lib/data/payment.ts
+++ b/apps/storefront/src/lib/data/payment.ts
@@ -22,7 +22,6 @@ export const listCartPaymentMethods = async (regionId: string) => {
         query: { region_id: regionId },
         headers,
         next,
-        cache: "force-cache",
       }
     )
     .then(({ payment_providers }) => payment_providers)

--- a/apps/storefront/src/lib/data/products.ts
+++ b/apps/storefront/src/lib/data/products.ts
@@ -34,7 +34,6 @@ export const getProductsById = async ({
       },
       headers,
       next,
-      cache: "force-cache",
     })
     .then(({ products }) => products)
 }
@@ -60,7 +59,6 @@ export const getProductByHandle = async (handle: string, regionId: string) => {
       },
       headers,
       next,
-      cache: "force-cache",
     })
     .then(({ products }) => products[0])
 }
@@ -113,7 +111,6 @@ export const listProducts = async ({
         },
         headers,
         next,
-        cache: "force-cache",
       }
     )
     .then(({ products, count }) => {

--- a/apps/storefront/src/lib/data/quotes.ts
+++ b/apps/storefront/src/lib/data/quotes.ts
@@ -109,7 +109,6 @@ export const acceptQuote = async (id: string) => {
       method: "POST",
       body: {},
       headers,
-      cache: "force-cache",
     })
     .then((res) => {
       track("quote_accepted", {
@@ -138,7 +137,6 @@ export const rejectQuote = async (id: string) => {
       method: "POST",
       body: {},
       headers,
-      cache: "force-cache",
     })
     .finally(async () => {
       const tags = await Promise.all([
@@ -163,7 +161,6 @@ export const createQuoteMessage = async (
       method: "POST",
       body,
       headers,
-      cache: "force-cache",
     })
     .then((res) => {
       track("quote_message_created", {

--- a/apps/storefront/src/lib/data/regions.ts
+++ b/apps/storefront/src/lib/data/regions.ts
@@ -14,7 +14,6 @@ export const listRegions = async (): Promise<HttpTypes.StoreRegion[]> => {
     .fetch<{ regions: HttpTypes.StoreRegion[] }>(`/store/regions`, {
       method: "GET",
       next,
-      cache: "force-cache",
     })
     .then(({ regions }: { regions: HttpTypes.StoreRegion[] }) => regions)
     .catch(medusaError)
@@ -31,7 +30,6 @@ export const retrieveRegion = async (
     .fetch<{ region: HttpTypes.StoreRegion }>(`/store/regions/${id}`, {
       method: "GET",
       next,
-      cache: "force-cache",
     })
     .then(({ region }: { region: HttpTypes.StoreRegion }) => region)
     .catch(medusaError)


### PR DESCRIPTION
The widespread usage of force-cache makes the page unusable as a starter. Changes on the admin don't reflect on the storefront and it's very confusing. There was probably a reason for using force-cache, so let's discuss here. In my view, it's an unnecessary optimization for a starter, and it makes the storefront pretty much static.