### PR TITLE
Fix "handle" for item preview

### DIFF
--- a/apps/storefront/src/modules/cart/components/item-preview/index.tsx
+++ b/apps/storefront/src/modules/cart/components/item-preview/index.tsx
@@ -13,7 +13,7 @@ type ItemProps = {
 }
 
 const ItemPreview = ({ item, showBorders = true, currencyCode }: ItemProps) => {
-  const { handle } = item.variant?.product ?? {}
+  const { handle } = item.product ?? {};
 
   const maxQuantity = item.variant?.inventory_quantity ?? 100
 


### PR DESCRIPTION
item.variant.product has only one proprty - id, that results in "undefined" in link in Cart preview