### PR TITLE
[codex] fix medusa model relationships

### DIFF
--- a/apps/backend/src/modules/company/models/company.ts
+++ b/apps/backend/src/modules/company/models/company.ts
@@ -1,5 +1,4 @@
 import { model } from "@medusajs/framework/utils";
-import { Employee } from "./employee";
 
 export const Company = model.define("company", {
   id: model
@@ -21,4 +20,17 @@ export const Company = model.define("company", {
     .enum(["never", "daily", "weekly", "monthly", "yearly"])
     .default("monthly"),
   employees: model.hasMany(() => Employee),
+});
+
+export const Employee = model.define("employee", {
+  id: model
+    .id({
+      prefix: "emp",
+    })
+    .primaryKey(),
+  spending_limit: model.bigNumber().default(0),
+  is_admin: model.boolean().default(false),
+  company: model.belongsTo(() => Company, {
+    mappedBy: "employees",
+  }),
 });

--- a/apps/backend/src/modules/company/models/employee.ts
+++ b/apps/backend/src/modules/company/models/employee.ts
@@ -1,15 +1,1 @@
-import { model } from "@medusajs/framework/utils";
-import { Company } from "./company";
-
-export const Employee = model.define("employee", {
-  id: model
-    .id({
-      prefix: "emp",
-    })
-    .primaryKey(),
-  spending_limit: model.bigNumber().default(0),
-  is_admin: model.boolean().default(false),
-  company: model.belongsTo(() => Company, {
-    mappedBy: "employees",
-  }),
-});
+export { Employee } from "./company";

--- a/apps/backend/src/modules/quote/models/message.ts
+++ b/apps/backend/src/modules/quote/models/message.ts
@@ -1,11 +1,1 @@
-import { model } from "@medusajs/framework/utils";
-import { Quote } from "./quote";
-
-export const Message = model.define("message", {
-  id: model.id({ prefix: "mess" }).primaryKey(),
-  text: model.text(),
-  item_id: model.text().nullable(),
-  admin_id: model.text().nullable(),
-  customer_id: model.text().nullable(),
-  quote: model.belongsTo(() => Quote, { mappedBy: "messages" }),
-});
+export { Message } from "./quote";

--- a/apps/backend/src/modules/quote/models/quote.ts
+++ b/apps/backend/src/modules/quote/models/quote.ts
@@ -1,5 +1,4 @@
 import { model } from "@medusajs/framework/utils";
-import { Message } from "./message";
 
 export const Quote = model.define("quote", {
   id: model.id({ prefix: "quo" }).primaryKey(),
@@ -17,4 +16,13 @@ export const Quote = model.define("quote", {
   order_change_id: model.text(),
   cart_id: model.text(),
   messages: model.hasMany(() => Message),
+});
+
+export const Message = model.define("message", {
+  id: model.id({ prefix: "mess" }).primaryKey(),
+  text: model.text(),
+  item_id: model.text().nullable(),
+  admin_id: model.text().nullable(),
+  customer_id: model.text().nullable(),
+  quote: model.belongsTo(() => Quote, { mappedBy: "messages" }),
 });


### PR DESCRIPTION
## Summary

Fixes the Medusa lint failure caused by direct cross-file model relationship imports in the custom company and quote modules.

The related model pairs are now co-located in their owning model files, while the previous sibling model files re-export the moved model. This keeps existing import paths working and preserves the generated schema shape for `company_id` and `quote_id` relationships.

## Root cause

Medusa's `@medusajs/link-no-cross-module-relationship` rule flagged direct relationship references imported from sibling model files as cross-module relationships, blocking `medusa develop` during lint.

## Validation

- `pnpm lint` passes with 0 errors
- `pnpm dev` no longer stops at the relationship lint failure and proceeds into the running dev server