### PR TITLE
feat: CI pipeline (lint, typecheck, tests, Playwright smoke) [SMD-113]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,176 @@
+# CI: lint, typecheck, unit + integration tests, and a Playwright smoke run
+# against a fully booted backend + storefront.
+#
+# Secrets policy: this workflow uses only low-sensitivity throwaway values
+# (CI-local database password, dummy JWT/cookie secrets). Real runtime secrets
+# live in Medusa Cloud per-environment settings, never here.
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Required by medusa-config.ts (no fallbacks since 2.18).
+  JWT_SECRET: ci-only-jwt-secret
+  COOKIE_SECRET: ci-only-cookie-secret
+  STORE_CORS: http://localhost:8000
+  ADMIN_CORS: http://localhost:9000
+  AUTH_CORS: http://localhost:9000
+
+jobs:
+  checks:
+    name: Lint, typecheck, tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4 # version comes from package.json "packageManager"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install (frozen lockfile)
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint backend
+        run: pnpm --filter @b2b-starter/backend lint
+
+      - name: Lint storefront
+        run: pnpm --filter @b2b-starter/storefront lint
+
+      - name: Typecheck backend
+        run: pnpm --filter @b2b-starter/backend exec tsc --noEmit
+
+      - name: Typecheck storefront
+        run: pnpm --filter @b2b-starter/storefront exec tsc --noEmit
+
+      - name: Build backend
+        run: pnpm --filter @b2b-starter/backend build
+
+      - name: Unit tests
+        run: pnpm --filter @b2b-starter/backend test:unit -- --passWithNoTests
+
+      - name: Integration tests (HTTP)
+        run: pnpm --filter @b2b-starter/backend test:integration:http
+        env:
+          DB_USERNAME: postgres
+          DB_PASSWORD: postgres
+
+  e2e:
+    name: E2E smoke (Playwright)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/b2b_ci
+      DB_NAME: b2b_ci
+      NEXT_PUBLIC_MEDUSA_BACKEND_URL: http://localhost:9000
+      NEXT_PUBLIC_BASE_URL: http://localhost:8000
+      NEXT_PUBLIC_DEFAULT_REGION: de
+      REVALIDATE_SECRET: ci-only-revalidate-secret
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install (frozen lockfile)
+        run: pnpm install --frozen-lockfile
+
+      - name: Create database
+        run: PGPASSWORD=postgres psql -h localhost -U postgres -c 'CREATE DATABASE b2b_ci'
+
+      - name: Migrate + seed
+        run: pnpm --filter @b2b-starter/backend exec medusa db:migrate
+
+      - name: Create admin user
+        run: pnpm --filter @b2b-starter/backend exec medusa user -e ci-admin@test.com -p ci-supersecret
+
+      - name: Start backend
+        run: |
+          nohup pnpm --filter @b2b-starter/backend dev > backend.log 2>&1 &
+          for i in $(seq 1 90); do
+            if curl -sf http://localhost:9000/health > /dev/null; then
+              echo "backend healthy after ${i} polls"; exit 0
+            fi
+            sleep 2
+          done
+          echo "backend did not become healthy"; tail -50 backend.log; exit 1
+
+      - name: Read publishable key
+        id: pk
+        run: |
+          KEY=$(PGPASSWORD=postgres psql -h localhost -U postgres -d b2b_ci -t -A -c "SELECT token FROM api_key WHERE type='publishable' LIMIT 1")
+          [ -n "$KEY" ] || { echo "no publishable key found"; exit 1; }
+          echo "key=$KEY" >> "$GITHUB_OUTPUT"
+
+      - name: Build storefront
+        run: pnpm --filter @b2b-starter/storefront build
+        env:
+          NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY: ${{ steps.pk.outputs.key }}
+
+      - name: Start storefront
+        run: |
+          nohup pnpm --filter @b2b-starter/storefront start > storefront.log 2>&1 &
+          for i in $(seq 1 60); do
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8000/de || true)
+            if [ "$CODE" = "200" ] || [ "$CODE" = "307" ]; then
+              echo "storefront up (HTTP $CODE) after ${i} polls"; exit 0
+            fi
+            sleep 2
+          done
+          echo "storefront did not come up"; tail -50 storefront.log; exit 1
+
+      - name: Install Playwright browsers
+        run: pnpm --filter @b2b-starter/e2e exec playwright install --with-deps chromium
+
+      - name: Run e2e smoke tests
+        run: pnpm --filter @b2b-starter/e2e test:e2e
+        env:
+          NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY: ${{ steps.pk.outputs.key }}
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            apps/e2e/playwright-report/
+            backend.log
+            storefront.log
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ yarn-error.log*
 ehthumbs.db
 Thumbs.db
 **/.DS_Store
+# Playwright
+**/test-results/
+**/playwright-report/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,92 @@
+# Development setup (this fork)
+
+This repo is a fork of [medusajs/b2b-starter](https://github.com/medusajs/b2b-starter) (monorepo: `apps/backend` = Medusa v2, `apps/storefront` = Next.js 15, pnpm + turbo). This guide supplements the upstream README with fork-specific and OS-specific notes.
+
+## Prerequisites
+
+- **Node.js 20+**
+- **pnpm 9** — pinned via `packageManager`; with corepack enabled the right version is used automatically
+- **PostgreSQL 15+** — a native install or Docker both work; only a reachable server is needed
+- **Redis: not required locally.** Without `REDIS_URL` the backend falls back to in-memory event bus/cache/locking (fine for dev; hosted environments use managed Redis)
+
+## First-time setup
+
+```bash
+pnpm install
+
+# create the database (any name; keep it in sync with .env)
+createdb b2b_dev   # or: psql -U postgres -c "CREATE DATABASE b2b_dev"
+```
+
+Create `apps/backend/.env` from `apps/backend/.env.template` and set:
+
+```bash
+DATABASE_URL=postgres://<user>:<password>@localhost:5432/b2b_dev
+DB_NAME=b2b_dev
+JWT_SECRET=<any-random-string>     # required — no fallback since v2.18 config
+COOKIE_SECRET=<any-random-string>  # required — no fallback since v2.18 config
+```
+
+Omit `REDIS_URL` unless you run Redis.
+
+Then:
+
+```bash
+cd apps/backend
+pnpm medusa db:migrate            # runs migrations AND the one-time data seed
+pnpm medusa user -e admin@test.com -p supersecret   # local admin login
+```
+
+`db:migrate` executes `src/migration-scripts/initial-data-seed.ts` on a fresh DB: sales channel, publishable API key, Europe region (gb/de/dk/se/fr/es/it), warehouse + shipping options, global product options, and 8 demo products.
+
+Create `apps/storefront/.env.local` from `apps/storefront/.env.template` and set:
+
+```bash
+NEXT_PUBLIC_MEDUSA_BACKEND_URL=http://localhost:9000
+NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=<pk_... from admin Settings → Publishable API Keys>
+NEXT_PUBLIC_BASE_URL=http://localhost:8000
+NEXT_PUBLIC_DEFAULT_REGION=de
+```
+
+> **Region gotcha:** the seed creates only a Europe region. `NEXT_PUBLIC_DEFAULT_REGION` must be one of its country codes (e.g. `de`) — the template's `us` 404s on every page.
+
+To grab the publishable key without opening the admin:
+
+```bash
+psql -U postgres -d b2b_dev -t -A -c "SELECT token FROM api_key WHERE type='publishable' LIMIT 1"
+```
+
+## Running
+
+```bash
+pnpm dev          # root: backend + storefront via turbo
+```
+
+- Backend + admin: http://localhost:9000 (admin UI at `/app`)
+- Storefront: http://localhost:8000
+
+> **Production builds:** `next build` (and therefore the root `pnpm build`) needs the **backend running** — the storefront pre-renders category/collection pages via `generateStaticParams` at build time. Start the backend first, then build the storefront. `medusa build` also runs `medusa lint`; lint **errors** fail the backend build.
+
+Reset the database at any time with drop + create + `db:migrate` (the seed re-runs on a fresh DB).
+
+## Windows notes
+
+- Use **Git Bash** for the backend test scripts (`test:unit` etc.) — they use `VAR=x` env prefixes that PowerShell/cmd don't support.
+- Stopping `pnpm dev` can orphan `node` processes that keep ports 8000/9000 bound. Find and kill them with:
+  ```powershell
+  Get-NetTCPConnection -LocalPort 8000,9000 -State Listen | ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }
+  ```
+
+## Dependency policy (freeze)
+
+Versions are **frozen** as of 2026-07-30: Medusa **2.18.0**, Next **15.5.21**, pnpm lockfile authoritative. Rules:
+
+1. No ad-hoc `pnpm up` / version bumps. CI installs with `--frozen-lockfile`; a drifted lockfile fails the build.
+2. Upgrades happen deliberately by merging the upstream starter: `git fetch upstream && git merge upstream/main`, then install → migrate → build → smoke-test before merging to `main`.
+3. `upstream` = https://github.com/medusajs/b2b-starter.
+
+## Branch / merge conventions
+
+- Branch per issue: `aviral/smd-<n>-<slug>` (Linear-generated name).
+- Merge to `main` only after the build is green and both apps have been smoke-tested locally.
+- Conventional commits (`feat:`, `fix:`, `chore:`, `docs:` …).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -69,9 +69,22 @@ pnpm dev          # root: backend + storefront via turbo
 
 Reset the database at any time with drop + create + `db:migrate` (the seed re-runs on a fresh DB).
 
+## Tests
+
+- **Unit** (`apps/backend`): `pnpm test:unit` — matches `src/**/__tests__/**/*.unit.spec.ts` (none yet; CI runs with `--passWithNoTests`).
+- **Integration** (`apps/backend`): `pnpm test:integration:http` — boots real app instances against throwaway Postgres databases. Needs `DB_USERNAME` / `DB_PASSWORD` env vars with rights to create databases.
+- **E2E smoke** (`apps/e2e`, Playwright): expects a **running** backend (9000) + storefront (8000), then `pnpm --filter @b2b-starter/e2e test:e2e`. First time: `pnpm --filter @b2b-starter/e2e exec playwright install chromium`. Set `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` to also exercise the store-API check.
+
+CI (`.github/workflows/ci.yml`) runs lint, typecheck, backend build, unit + integration tests, and the e2e smoke suite on PRs and pushes to `main`.
+
 ## Windows notes
 
-- Use **Git Bash** for the backend test scripts (`test:unit` etc.) — they use `VAR=x` env prefixes that PowerShell/cmd don't support.
+- pnpm executes package scripts through **cmd.exe**, so scripts with `VAR=x` env prefixes (the backend `test:*` scripts) fail even from Git Bash. Either set the env vars in Git Bash and call jest directly:
+  ```bash
+  TEST_TYPE=integration:http NODE_OPTIONS=--experimental-vm-modules \
+  DB_USERNAME=postgres DB_PASSWORD=<pw> pnpm exec jest --runInBand --forceExit
+  ```
+  or point pnpm at bash once: `pnpm config set script-shell "C:\\Program Files\\Git\\bin\\bash.exe"`.
 - Stopping `pnpm dev` can orphan `node` processes that keep ports 8000/9000 bound. Find and kill them with:
   ```powershell
   Get-NetTCPConnection -LocalPort 8000,9000 -State Listen | ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ An official Medusa starter for B2B ecommerce, built with [Medusa](https://medusa
 
 ## Getting Started
 
+> **Working on this fork?** See [DEVELOPMENT.md](DEVELOPMENT.md) for local setup (incl. Windows notes), the dependency-freeze policy, and branch/merge conventions.
+
 ### Deploy with Medusa Cloud
 
 The fastest way to get started is deploying with [Medusa Cloud](https://cloud.medusajs.com):

--- a/apps/backend/integration-tests/http/quotes/quotes.spec.ts
+++ b/apps/backend/integration-tests/http/quotes/quotes.spec.ts
@@ -91,7 +91,6 @@ medusaIntegrationTestRunner({
               ],
               summary: expect.objectContaining({
                 paid_total: 0,
-                difference_sum: 0,
                 refunded_total: 0,
                 transaction_total: 0,
                 pending_difference: 100,

--- a/apps/backend/integration-tests/utils/admin.ts
+++ b/apps/backend/integration-tests/utils/admin.ts
@@ -43,7 +43,7 @@ export const createAdminUser = async (adminHeaders, appContainer) => {
       actor_type: "user",
       auth_identity_id: authIdentity.id,
     },
-    process.env.JWT_SECRET,
+    process.env.JWT_SECRET ?? "supersecret",
     {
       expiresIn: "1d",
     }

--- a/apps/backend/integration-tests/utils/seeder.ts
+++ b/apps/backend/integration-tests/utils/seeder.ts
@@ -25,6 +25,7 @@ export async function productSeeder({ api, adminHeaders, data }) {
       {
         title: `Test Product`,
         handle: `test-product`,
+        status: "published",
         options: [
           { title: "size", values: ["large", "small"] },
           { title: "color", values: ["green"] },

--- a/apps/backend/src/admin/routes/quotes/components/quote-manage/manage-items-section.tsx
+++ b/apps/backend/src/admin/routes/quotes/components/quote-manage/manage-items-section.tsx
@@ -1,8 +1,4 @@
-import {
-  AdminOrder,
-  AdminOrderLineItem,
-  AdminOrderPreview,
-} from "@medusajs/framework/types";
+import { AdminOrder, AdminOrderPreview } from "@medusajs/framework/types";
 import { Button, Heading, Input, toast } from "@medusajs/ui";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -61,7 +57,7 @@ export const ManageItemsSection = ({
       (i) =>
         i.title.toLowerCase().includes(filterTerm) ||
         i.product_title?.toLowerCase().includes(filterTerm)
-    ) as AdminOrderLineItem[];
+    );
   }, [preview, filterTerm]);
 
   const originalItemsMap = useMemo(() => {

--- a/apps/backend/src/workflows/quote/workflows/create-request-for-quote.ts
+++ b/apps/backend/src/workflows/quote/workflows/create-request-for-quote.ts
@@ -61,7 +61,19 @@ export const createRequestForQuoteWorkflow = createWorkflow(
         customer_id: customer.id,
         billing_address: cart.billing_address,
         shipping_address: cart.shipping_address,
-        items: cart.items,
+        // Freeze the cart's resolved prices onto the draft order explicitly:
+        // passing raw cart items makes 2.18's createOrdersWorkflow re-resolve
+        // prices in an order context, which yields null unit prices.
+        items: cart.items.map((item) => ({
+          title: item.title,
+          subtitle: item.subtitle,
+          thumbnail: item.thumbnail,
+          variant_id: item.variant_id,
+          quantity: item.quantity,
+          unit_price: item.unit_price,
+          compare_at_unit_price: item.compare_at_unit_price,
+          metadata: item.metadata,
+        })),
         region_id: cart.region_id,
         promo_codes: cart.promotions.map(({ code }) => code),
         currency_code: cart.currency_code,

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@b2b-starter/e2e",
+  "version": "0.0.1",
+  "private": true,
+  "description": "End-to-end smoke tests (Playwright) against a running backend + storefront.",
+  "scripts": {
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.62.0",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Runs against an already-running stack:
+ *   backend    http://localhost:9000  (override: BACKEND_URL)
+ *   storefront http://localhost:8000  (override: STOREFRONT_URL)
+ * See DEVELOPMENT.md for how to boot both.
+ */
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI
+    ? [["line"], ["html", { open: "never" }]]
+    : [["list"]],
+  expect: { timeout: 15_000 },
+  use: {
+    baseURL: process.env.STOREFRONT_URL ?? "http://localhost:8000",
+    trace: "on-first-retry",
+    navigationTimeout: 30_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/apps/e2e/tests/smoke.spec.ts
+++ b/apps/e2e/tests/smoke.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test";
+
+const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:9000";
+
+// The seed creates a Europe region only; "de" belongs to it.
+const COUNTRY = process.env.E2E_COUNTRY_CODE ?? "de";
+
+test("backend is healthy", async ({ request }) => {
+  const res = await request.get(`${BACKEND_URL}/health`);
+  expect(res.status()).toBe(200);
+});
+
+test("store API serves products with the publishable key", async ({
+  request,
+}) => {
+  const key = process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY;
+  test.skip(!key, "NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY not set");
+
+  const res = await request.get(`${BACKEND_URL}/store/products?limit=1`, {
+    headers: { "x-publishable-api-key": key! },
+  });
+  expect(res.status()).toBe(200);
+  const body = await res.json();
+  expect(body.count).toBeGreaterThan(0);
+});
+
+test("storefront home renders", async ({ page }) => {
+  await page.goto(`/${COUNTRY}`);
+  await expect(page.locator("footer")).toBeVisible();
+});
+
+test("catalog lists products", async ({ page }) => {
+  await page.goto(`/${COUNTRY}/store`);
+  const productLinks = page.locator(`a[href*="/products/"]`);
+  await expect(productLinks.first()).toBeVisible();
+});
+
+test("product page shows a variant picker and price", async ({ page }) => {
+  await page.goto(`/${COUNTRY}/store`);
+  await page.locator(`a[href*="/products/"]`).first().click();
+  await expect(page).toHaveURL(new RegExp(`/${COUNTRY}/products/`));
+  // Any rendered price implies region/pricing wiring works end-to-end.
+  await expect(page.getByText(/€|\$|EUR|USD/).first()).toBeVisible();
+});

--- a/apps/e2e/tsconfig.json
+++ b/apps/e2e/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["tests/**/*.ts", "playwright.config.ts"]
+}

--- a/apps/storefront/package.json
+++ b/apps/storefront/package.json
@@ -40,7 +40,7 @@
     "react-markdown": "^9.0.1",
     "server-only": "^0.0.1",
     "webpack": "^5",
-    "zod": "^3.24.0"
+    "zod": "4.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.17.5",

--- a/apps/storefront/src/modules/account/components/profile-card/index.tsx
+++ b/apps/storefront/src/modules/account/components/profile-card/index.tsx
@@ -54,7 +54,7 @@ const ProfileCard = ({ customer }: { customer: B2BCustomer }) => {
             <Input
               label="First Name"
               name="first_name"
-              value={customerData.first_name}
+              value={customerData.first_name ?? ""}
               onChange={(e) =>
                 setCustomerData({
                   ...customerData,
@@ -68,7 +68,7 @@ const ProfileCard = ({ customer }: { customer: B2BCustomer }) => {
             <Input
               label="Last Name"
               name="last_name"
-              value={customerData.last_name}
+              value={customerData.last_name ?? ""}
               onChange={(e) =>
                 setCustomerData({
                   ...customerData,
@@ -86,7 +86,7 @@ const ProfileCard = ({ customer }: { customer: B2BCustomer }) => {
             <Input
               label="Phone"
               name="phone"
-              value={customerData.phone}
+              value={customerData.phone ?? ""}
               onChange={(e) =>
                 setCustomerData({ ...customerData, phone: e.target.value })
               }

--- a/apps/storefront/src/modules/cart/components/cart-drawer/index.tsx
+++ b/apps/storefront/src/modules/cart/components/cart-drawer/index.tsx
@@ -29,9 +29,9 @@ const CartDrawer = ({
   freeShippingPrices,
   ...props
 }: CartDrawerProps) => {
-  const [activeTimer, setActiveTimer] = useState<NodeJS.Timer | undefined>(
-    undefined
-  )
+  const [activeTimer, setActiveTimer] = useState<
+    ReturnType<typeof setTimeout> | undefined
+  >(undefined)
   const [isOpen, setIsOpen] = useState(false)
 
   const open = () => setIsOpen(true)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clean": "turbo run clean && rm -rf node_modules"
   },
   "devDependencies": {
-    "@medusajs/eslint-plugin": "2.16.0",
+    "@medusajs/eslint-plugin": "2.18.0",
     "eslint": "^9.13.0",
     "jiti": "^2.7.0",
     "turbo": "^2.3.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,15 @@ importers:
         specifier: ^5.2.11
         version: 5.4.21(@types/node@20.19.27)(terser@5.44.1)
 
+  apps/e2e:
+    devDependencies:
+      '@playwright/test':
+        specifier: 1.62.0
+        version: 1.62.0
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.27
+
   apps/storefront:
     dependencies:
       '@headlessui/react':
@@ -147,16 +156,16 @@ importers:
         version: 8.6.0
       '@vercel/analytics':
         specifier: ^1.4.1
-        version: 1.6.1(next@15.5.21(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5))(react@19.0.5)
+        version: 1.6.1(next@15.5.21(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5))(react@19.0.5)
       geist:
         specifier: ^1.3.1
-        version: 1.5.1(next@15.5.21(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5))
+        version: 1.5.1(next@15.5.21(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5))
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
       next:
         specifier: 15.5.21
-        version: 15.5.21(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+        version: 15.5.21(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
       pg:
         specifier: ^8.11.3
         version: 8.16.3
@@ -185,8 +194,8 @@ importers:
         specifier: ^5
         version: 5.104.0
       zod:
-        specifier: ^3.24.0
-        version: 3.25.76
+        specifier: 4.2.0
+        version: 4.2.0
     devDependencies:
       '@babel/core':
         specifier: ^7.17.5
@@ -2202,6 +2211,11 @@ packages:
 
   '@paypal/sdk-constants@1.0.157':
     resolution: {integrity: sha512-BjxWT9rK6dM1AOffSpvHYY47/8BY775jgEYYiwH6eL4YaqU5Epcw7zOtwQ8L4UaEn4FCAjZ2EWxaS83dCN7SpA==}
+
+  '@playwright/test@1.62.0':
+    resolution: {integrity: sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@posthog/core@1.8.1':
     resolution: {integrity: sha512-jfzBtQIk9auRi/biO+G/gumK5KxqsD5wOr7XpYMROE/I3pazjP4zIziinp21iQuIQJMXrDvwt9Af3njgOGwtew==}
@@ -5889,6 +5903,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -7382,6 +7401,16 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
+  playwright-core@1.62.0:
+    resolution: {integrity: sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.0:
+    resolution: {integrity: sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
@@ -8764,9 +8793,6 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
-
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.2.0:
     resolution: {integrity: sha512-Bd5fw9wlIhtqCCxotZgdTOMwGm1a0u75wARVEY9HMs1X17trvA/lMi4+MGK5EUfYkXVTbX8UDiDKW4OgzHVUZw==}
@@ -11707,6 +11733,10 @@ snapshots:
   '@paypal/sdk-constants@1.0.157':
     dependencies:
       hi-base32: 0.5.1
+
+  '@playwright/test@1.62.0':
+    dependencies:
+      playwright: 1.62.0
 
   '@posthog/core@1.8.1':
     dependencies:
@@ -16318,9 +16348,9 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@1.6.1(next@15.5.21(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5))(react@19.0.5)':
+  '@vercel/analytics@1.6.1(next@15.5.21(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5))(react@19.0.5)':
     optionalDependencies:
-      next: 15.5.21(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      next: 15.5.21(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
       react: 19.0.5
 
   '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@20.19.27)(terser@5.44.1))':
@@ -17954,6 +17984,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -17970,9 +18003,9 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
-  geist@1.5.1(next@15.5.21(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)):
+  geist@1.5.1(next@15.5.21(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)):
     dependencies:
-      next: 15.5.21(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      next: 15.5.21(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
 
   generator-function@2.0.1: {}
 
@@ -19449,7 +19482,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@15.5.21(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5):
+  next@15.5.21(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5):
     dependencies:
       '@next/env': 15.5.21
       '@swc/helpers': 0.5.15
@@ -19468,6 +19501,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 15.5.21
       '@next/swc-win32-x64-msvc': 15.5.21
       '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.62.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -19764,6 +19798,14 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  playwright-core@1.62.0: {}
+
+  playwright@1.62.0:
+    dependencies:
+      playwright-core: 1.62.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize@8.0.0: {}
 
@@ -21612,8 +21654,6 @@ snapshots:
   zod-validation-error@5.0.0(zod@4.2.0):
     dependencies:
       zod: 4.2.0
-
-  zod@3.25.76: {}
 
   zod@4.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
   .:
     devDependencies:
       '@medusajs/eslint-plugin':
-        specifier: 2.16.0
-        version: 2.16.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        specifier: 2.18.0
+        version: 2.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint:
         specifier: ^9.13.0
         version: 9.39.4(jiti@2.7.0)
@@ -1502,8 +1502,8 @@ packages:
       react-router-dom:
         optional: true
 
-  '@medusajs/eslint-plugin@2.16.0':
-    resolution: {integrity: sha512-VBknFF/B6SM4lq5EAJoduYj0M6dkg6qK+JN8cRYELkQZAg8y3nUGvLsh+GxI8X9OQFjHeoPsfvzASVLsfnnwzg==}
+  '@medusajs/eslint-plugin@2.18.0':
+    resolution: {integrity: sha512-Xsy9dPD5RTEvbMmjtw8dPIsNxXgTVYbubtFALIc6zbISlFUClWK7EAMiQb08IaLxf4a6LaSW7ZzMHwh5xcEC8g==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -10670,7 +10670,7 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  '@medusajs/eslint-plugin@2.16.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@medusajs/eslint-plugin@2.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/parser': 8.50.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/utils': 8.50.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)


### PR DESCRIPTION
## Summary
- GitHub Actions CI on PRs and pushes to main, two jobs:
  - **checks**: frozen-lockfile install, backend + storefront lint, strict typecheck (both apps), backend build, unit-test lane (`--passWithNoTests` until unit specs land), and the backend HTTP integration suite against a Postgres 17 service.
  - **e2e**: migrate + seed a fresh DB, boot backend + storefront, then run the new `apps/e2e` Playwright smoke suite (backend health, store API with publishable key, home, catalog, product page).
- Fixes required to get every lane green on Medusa 2.18:
  - quote flow regression: draft orders created from carts lost their unit prices — prices are now frozen explicitly onto the draft order (verified live and by the integration suite, 15/15).
  - integration fixture rot: seeded test product must be `published`; `difference_sum` no longer exists on order summaries.
  - 8 strict-typecheck errors across both apps, incl. unifying the workspace on zod 4.2.0 (type bleed via `shamefully-hoist`).
- Secrets policy: workflow uses throwaway CI-only values; real secrets stay in Medusa Cloud per-environment settings.

## Test plan
- All lanes run green locally (lint 0 errors, tsc clean both apps, 15/15 integration, 5/5 Playwright against the built storefront).
- This PR's CI run is the real verification on Linux runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)