### PR TITLE
fix: filter zero-quantity variants in bulk add-to-cart

### DIFF
--- a/apps/storefront/src/modules/products/components/bulk-table-quantity/index.tsx
+++ b/apps/storefront/src/modules/products/components/bulk-table-quantity/index.tsx
@@ -13,7 +13,11 @@ const BulkTableQuantity = ({ variantId, onChange }: BulkTableQuantityProps) => {
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setQuantity(e.target.value)
-    onChange(variantId, Number(e.target.value))
+    const parsed = Number(e.target.value)
+    onChange(
+      variantId,
+      Number.isFinite(parsed) ? Math.max(Math.floor(parsed), 0) : 0
+    )
   }
 
   const handleAdd = () => {

--- a/apps/storefront/src/modules/products/components/product-variants-table/index.tsx
+++ b/apps/storefront/src/modules/products/components/product-variants-table/index.tsx
@@ -54,19 +54,21 @@ const ProductVariantsTable = ({
   const handleAddToCart = async () => {
     setIsAdding(true)
 
-    const lineItems = Array.from(lineItemsMap.entries()).map(
-      ([variantId, { quantity, ...variant }]) => ({
+    const lineItems = Array.from(lineItemsMap.entries())
+      .filter(([, { quantity }]) => Number.isFinite(quantity) && quantity > 0)
+      .map(([variantId, { quantity, ...variant }]) => ({
         productVariant: {
           ...variant,
         },
         quantity,
-      })
-    )
+      }))
 
-    addToCartEventBus.emitCartAdd({
-      lineItems,
-      regionId: region.id,
-    })
+    if (lineItems.length > 0) {
+      addToCartEventBus.emitCartAdd({
+        lineItems,
+        regionId: region.id,
+      })
+    }
 
     setIsAdding(false)
   }


### PR DESCRIPTION
Fixes #30

`handleAddToCart` in `ProductVariantsTable` sends every entry in `lineItemsMap`, including variants whose quantity was touched and set back to 0. The backend rejects the whole bulk request with `400 "Item quantity must be greater than 0"`, so nothing can be added once any row was zeroed.

- `ProductVariantsTable`: drop non-positive quantities when building line items; skip the request when nothing remains
- `BulkTableQuantity`: clamp typed input (negative/decimal/empty) to a non-negative integer before reporting to the parent

Verified against a running backend: the repro path (set a row to 1, back to 0, another row to 1, add to cart) now returns 200 and only the positive-quantity variant is added. Server-side, `StoreAddLineItemsBulk` could additionally require a positive integer quantity — happy to include that here if you'd like.
