### PR TITLE
fix: stop fall-through quantity updates on cart items

### DIFF
--- a/apps/storefront/src/modules/cart/components/item-full/index.tsx
+++ b/apps/storefront/src/modules/cart/components/item-full/index.tsx
@@ -47,18 +47,25 @@ const ItemFull = ({
   }, [item.quantity])
 
   const handleBlur = (value: number) => {
+    if (!Number.isFinite(value)) {
+      setQuantity(item.quantity.toString())
+      return
+    }
+
     if (value === item.quantity) {
       return
     }
 
     if (value > maxQuantity) {
       changeQuantity(maxQuantity)
+      return
     }
 
     if (value < 1) {
       setUpdating(true)
       handleDeleteItem(item.id)
       setUpdating(false)
+      return
     }
 
     changeQuantity(value)
@@ -70,7 +77,7 @@ const ItemFull = ({
     }
 
     if (e.key === "Enter") {
-      changeQuantity(Number(quantity))
+      handleBlur(Number(quantity))
     }
 
     if (e.key === "ArrowUp" && e.shiftKey) {


### PR DESCRIPTION
Fixes #32

`handleBlur` in the cart item component is missing `return` statements, so branches fall through and fire extra invalid updates: an over-stock value is clamped and then sent unclamped anyway, a value below 1 deletes the item and then still updates the deleted item, and a cleared input submits `NaN` (it fails every comparison). The Enter key path submits the raw input value with no validation at all.

- add the missing early returns in `handleBlur`
- restore the previous quantity when the input is not a number
- route Enter through the same clamping logic instead of calling `changeQuantity` directly

Related to #30 / #31 — same underlying pattern (unvalidated quantity input reaching the cart API), different component.
